### PR TITLE
Use thread_mattr_accessor instead of deprecated ActiveSupport::PerThreadRegistry

### DIFF
--- a/garage_client-rails.gemspec
+++ b/garage_client-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "garage_client"
-  spec.add_dependency "rails", '>= 4.0.0'
+  spec.add_dependency "rails", '>= 5.0.0'
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/garage_client/rails/runtime_registry.rb
+++ b/lib/garage_client/rails/runtime_registry.rb
@@ -2,8 +2,6 @@ require 'active_support/per_thread_registry'
 
 module GarageClient::Rails
   class RuntimeRegistry
-    extend ActiveSupport::PerThreadRegistry
-
-    attr_accessor :garage_client_runtime
+    thread_mattr_accessor :garage_client_runtime
   end
 end

--- a/lib/garage_client/rails/version.rb
+++ b/lib/garage_client/rails/version.rb
@@ -1,5 +1,5 @@
 module GarageClient
   module Rails
-    VERSION = "0.0.2"
+    VERSION = "0.0.3"
   end
 end

--- a/lib/garage_client/rails/version.rb
+++ b/lib/garage_client/rails/version.rb
@@ -1,5 +1,5 @@
 module GarageClient
   module Rails
-    VERSION = "0.0.3"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
ActiveSupport::PerThreadRegistry is [deprecated](https://api.rubyonrails.org/classes/ActiveSupport/PerThreadRegistry.html).
Use [thread_mattr_accessor](https://api.rubyonrails.org/classes/Module.html#method-i-thread_mattr_accessor) to follow document suggestion.
