### PR TITLE
Update Rails7.1

### DIFF
--- a/garage_client-rails.gemspec
+++ b/garage_client-rails.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "garage_client"
-  spec.add_dependency "rails", '>= 5.0.0'
+  spec.add_dependency "rails", '>= 7.1.0'
 
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec"

--- a/lib/garage_client/rails/runtime_registry.rb
+++ b/lib/garage_client/rails/runtime_registry.rb
@@ -1,4 +1,4 @@
-require 'active_support/per_thread_registry'
+require 'active_support/core_ext/module/attribute_accessors_per_thread'
 
 module GarageClient::Rails
   class RuntimeRegistry

--- a/lib/garage_client/rails/version.rb
+++ b/lib/garage_client/rails/version.rb
@@ -1,5 +1,5 @@
 module GarageClient
   module Rails
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
   end
 end


### PR DESCRIPTION
In Rails7.1, `thread_mattr_accessor` [moved](https://github.com/rails/rails/blob/v7.1.1/activesupport/lib/active_support/core_ext/module/attribute_accessors_per_thread.rb#L41) into `active_support/core_ext/module/attribute_accessors_per_thread` so we change require path.
