### PR TITLE
Change color style to fix deprecation warning

### DIFF
--- a/lib/garage_client/rails/log_subscriber.rb
+++ b/lib/garage_client/rails/log_subscriber.rb
@@ -24,10 +24,10 @@ module GarageClient::Rails
 
       payload = event.payload
 
-      name   = color("GarageClient (#{event.duration.round(1)}ms)", GREEN, true)
-      method = color(payload[:method].to_s.upcase, WHITE, true)
-      url    = color(payload[:url], WHITE, true)
-      body   = (payload[:body].nil? ? nil : color(payload[:body], WHITE, false))
+      name   = color("GarageClient (#{event.duration.round(1)}ms)", :green, bold: true)
+      method = color(payload[:method].to_s.upcase, :white, bold: true)
+      url    = color(payload[:url], :white, bold: true)
+      body   = (payload[:body].nil? ? nil : color(payload[:body], :white, bold: false))
 
       message = ""
       message << "  #{name} #{method} #{url}"

--- a/lib/garage_client/rails/version.rb
+++ b/lib/garage_client/rails/version.rb
@@ -1,5 +1,5 @@
 module GarageClient
   module Rails
-    VERSION = "1.1.0"
+    VERSION = "1.1.1"
   end
 end


### PR DESCRIPTION
In Rails 7.1, we found following deprecation warning: 

```
DEPRECATION WARNING: Bolding log text with a positional boolean is deprecated and will be removed in Rails 7.2. Use an option hash instead (eg. `color("my text", :red, bold: true)`). 
```

This PR fix it and bump version to 1.1.1